### PR TITLE
Fix: Added expense entry cancellation to also delete journal entries

### DIFF
--- a/expense_request/expense_request/doctype/expense_entry/expense_entry.py
+++ b/expense_request/expense_request/doctype/expense_entry/expense_entry.py
@@ -3,8 +3,26 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class ExpenseEntry(Document):
-	pass
+	
+	def on_cancel(self):
+		# Find and cancel linked journal entries
+		je_list = frappe.get_all("Journal Entry", 
+			filters={
+				"bill_no": self.name,
+				"docstatus": 1
+			})
+		
+		for je in je_list:
+			journal_entry = frappe.get_doc("Journal Entry", je.name)
+			if journal_entry.docstatus == 1:
+				# Cancel journal entry
+				journal_entry.cancel()
+				frappe.msgprint(f"Journal Entry {journal_entry.name} has been cancelled.")
+				
+				# Now delete the journal entry
+				frappe.delete_doc("Journal Entry", journal_entry.name, force=1)
+				frappe.msgprint(f"Journal Entry {journal_entry.name} has been deleted.")


### PR DESCRIPTION
- Clean Database: Journal entries of cancelled expense entries will be removed from the database, helping to control database size
- Better Workflow: When an expense entry is created after cancel old expense entry, new journal entries will be created without any conflicts from old entries
- Accounting Accuracy: Deleting journal entries of cancelled expenses will prevent inconsistencies in accounting records
- User Experience: Users will receive clear feedback that the journal entry has been cancelled and deleted
- System Performance: System performance will improve by removing unnecessary cancelled journal entries
- Data Integrity: Proper synchronization between expense entries and their journal entries will be maintained